### PR TITLE
ci: add podman tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - name: Manual podman install (else 3.4.4 is installed)
+        run: |
+          apt-get update
+          apt-get install -y podman
       - name: Build
         run: cargo build --verbose --features ensure-podman
       - name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - name: Install podman compose
         run: |
-          pip3 install --user podman-compose
+          pipx install podman-compose
       - name: Build
         run: cargo build --verbose --features ensure-podman
       - name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,11 @@ jobs:
         run: cargo test --verbose
 
   tests_with_podman:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - rust: $MSRV
           - rust: stable
-          - rust: beta
-          - rust: nightly
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Manual podman install (else 3.4.4 is installed)
-        run: |
-          apt-get update
-          apt-get install -y podman
       - name: Build
         run: cargo build --verbose --features ensure-podman
       - name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - name: Install podman compose
+        run: |
+          pip3 install --user podman-compose
       - name: Build
         run: cargo build --verbose --features ensure-podman
       - name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,28 @@ jobs:
       - name: Tests
         run: cargo test --verbose
 
+  tests_with_podman:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - rust: $MSRV
+          - rust: stable
+          - rust: beta
+          - rust: nightly
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Build
+        run: cargo build --verbose --features ensure-podman
+      - name: Documentation
+        run: cargo doc --verbose --features ensure-podman
+      - name: Tests
+        run: cargo test --verbose --features ensure-podman
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: cargo test --verbose
 
   tests_with_podman:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:

--- a/rustainers/src/runner/podman.rs
+++ b/rustainers/src/runner/podman.rs
@@ -13,8 +13,7 @@ use crate::IpamNetworkConfig;
 use crate::NetworkInfo;
 
 use super::{ContainerError, InnerRunner, RunnerError};
-
-const MINIMAL_VERSION: Version = Version::new(4, 0);
+const MINIMAL_VERSION: Version = Version::new(3, 4);
 const COMPOSE_MINIMAL_VERSION: Version = Version::new(1, 0);
 
 /// A Podman runner

--- a/rustainers/src/runner/podman.rs
+++ b/rustainers/src/runner/podman.rs
@@ -13,7 +13,7 @@ use crate::IpamNetworkConfig;
 use crate::NetworkInfo;
 
 use super::{ContainerError, InnerRunner, RunnerError};
-const MINIMAL_VERSION: Version = Version::new(4, 0);
+const MINIMAL_VERSION: Version = Version::new(3, 4);
 const COMPOSE_MINIMAL_VERSION: Version = Version::new(1, 0);
 
 /// A Podman runner

--- a/rustainers/src/runner/podman.rs
+++ b/rustainers/src/runner/podman.rs
@@ -13,7 +13,7 @@ use crate::IpamNetworkConfig;
 use crate::NetworkInfo;
 
 use super::{ContainerError, InnerRunner, RunnerError};
-const MINIMAL_VERSION: Version = Version::new(3, 4);
+const MINIMAL_VERSION: Version = Version::new(4, 0);
 const COMPOSE_MINIMAL_VERSION: Version = Version::new(1, 0);
 
 /// A Podman runner

--- a/rustainers/src/runner/podman.rs
+++ b/rustainers/src/runner/podman.rs
@@ -93,15 +93,15 @@ pub(super) fn create() -> Result<Podman, RunnerError> {
     let mut cmd = Cmd::new("podman");
     cmd.push_args(["version", "--format", "json"]);
     let Ok(Some(version)) = cmd.json_blocking::<Option<PodmanVersion>>() else {
-        return Err(RunnerError::CommandNotAvailable(String::from("docker")));
+        return Err(RunnerError::CommandNotAvailable(String::from("podman")));
     };
 
     // Check client version
     let current = version.client.api_version;
-    debug!("Found docker version: {current}");
+    debug!("Found podman version: {current}");
     if current < MINIMAL_VERSION {
         return Err(RunnerError::UnsupportedVersion {
-            command: String::from("docker"),
+            command: String::from("podman"),
             current,
             minimal: MINIMAL_VERSION,
         });

--- a/rustainers/tests/common/mod.rs
+++ b/rustainers/tests/common/mod.rs
@@ -24,8 +24,14 @@ pub fn init_test_tracing(level: Level) {
 pub fn runner() -> Runner {
     init_test_tracing(Level::INFO);
 
-    #[allow(clippy::expect_used)]
-    let runner = Runner::auto().expect("Should find a valid runner");
+    let runner = if cfg!(feature = "ensure-podman") {
+        #[allow(clippy::expect_used)]
+        Runner::podman().expect("Should find a valid runner")
+    } else {
+        #[allow(clippy::expect_used)]
+        Runner::auto().expect("Should find a valid runner")
+    };
+
     debug!("Using runner {runner:?}");
     runner
 }


### PR DESCRIPTION
# Add podman support in ci

Unfortunately it requires a `ubuntu-24.04` as a runner instead of the `ubuntu-22-04` used for docker tests. Indeed, the podman version in 22-04 is 3.4 which is below the minimum requirements.

