### PR TITLE
fix: Prefix all short-name images for new Podman compatibility

### DIFF
--- a/rustainers/examples/custom_image.rs
+++ b/rustainers/examples/custom_image.rs
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-const NGINX_IMAGE: &ImageName = &ImageName::new("nginx");
+const NGINX_IMAGE: &ImageName = &ImageName::new("docker.io/nginx");
 
 const PORT: u16 = 80;
 

--- a/rustainers/src/container/runnable.rs
+++ b/rustainers/src/container/runnable.rs
@@ -13,7 +13,7 @@ use crate::{ExposedPort, ImageReference, WaitStrategy};
 /// # use std::time::Duration;
 /// # use rustainers::{RunnableContainer, HealthCheck, ExposedPort, ImageName};
 /// let runnable = RunnableContainer::builder()
-///     .with_image(ImageName::new("redis"))
+///     .with_image(ImageName::new("docker.io/redis"))
 ///     .with_wait_strategy(
 ///         HealthCheck::builder()
 ///             .with_command("redis-cli --raw incr ping")

--- a/rustainers/src/image/name.rs
+++ b/rustainers/src/image/name.rs
@@ -14,7 +14,7 @@ use super::ImageNameError;
 ///
 /// ```rust
 /// # use rustainers::ImageName;
-/// const POSTGRES_IMAGE: &ImageName = &ImageName::new("postgres");
+/// const POSTGRES_IMAGE: &ImageName = &ImageName::new("docker.io/postgres");
 ///```
 ///
 /// Parse an image name:

--- a/rustainers/src/images/alpine.rs
+++ b/rustainers/src/images/alpine.rs
@@ -11,7 +11,7 @@ pub struct Alpine;
 impl ToRunnableContainer for Alpine {
     fn to_runnable(&self, builder: RunnableContainerBuilder) -> RunnableContainer {
         builder
-            .with_image(ImageName::new("alpine"))
+            .with_image(ImageName::new("docker.io/alpine"))
             .with_wait_strategy(WaitStrategy::None)
             // keep the container alive
             .with_command(["tail", "-f", "/dev/null"])

--- a/rustainers/src/images/doc.md
+++ b/rustainers/src/images/doc.md
@@ -19,7 +19,7 @@ use rustainers::{
 
 // Declare the image as a constant.
 // You can provide a tag or a digest if you want.
-const NGINX_IMAGE: &ImageName = &ImageName::new("nginx");
+const NGINX_IMAGE: &ImageName = &ImageName::new("docker.io/nginx");
 
 const PORT: u16 = 80;
 

--- a/rustainers/src/images/minio.rs
+++ b/rustainers/src/images/minio.rs
@@ -8,7 +8,7 @@ use crate::{
 
 const DATA: &str = "/data";
 
-const MINIO_IMAGE: &ImageName = &ImageName::new("minio/minio");
+const MINIO_IMAGE: &ImageName = &ImageName::new("docker.io/minio/minio");
 
 const PORT: Port = Port(9000);
 

--- a/rustainers/src/images/mongo.rs
+++ b/rustainers/src/images/mongo.rs
@@ -3,7 +3,7 @@ use crate::{
     RunnableContainerBuilder, ToRunnableContainer, WaitStrategy,
 };
 
-const MONGO_IMAGE: &ImageName = &ImageName::new("mongo");
+const MONGO_IMAGE: &ImageName = &ImageName::new("docker.io/mongo");
 
 const PORT: Port = Port(27017);
 

--- a/rustainers/src/images/mosquitto.rs
+++ b/rustainers/src/images/mosquitto.rs
@@ -5,7 +5,7 @@ use crate::{
     RunnableContainerBuilder, ToRunnableContainer, WaitStrategy,
 };
 
-const MOSQUITTO_IMAGE: &ImageName = &ImageName::new("eclipse-mosquitto");
+const MOSQUITTO_IMAGE: &ImageName = &ImageName::new("docker.io/eclipse-mosquitto");
 
 const PORT: Port = Port(6379);
 

--- a/rustainers/src/images/postgres.rs
+++ b/rustainers/src/images/postgres.rs
@@ -5,7 +5,7 @@ use crate::{
     RunnableContainerBuilder, ToRunnableContainer,
 };
 
-const POSTGRES_IMAGE: &ImageName = &ImageName::new("postgres");
+const POSTGRES_IMAGE: &ImageName = &ImageName::new("docker.io/postgres");
 
 const PORT: Port = Port(5432);
 

--- a/rustainers/src/images/redis.rs
+++ b/rustainers/src/images/redis.rs
@@ -5,7 +5,7 @@ use crate::{
     RunnableContainerBuilder, ToRunnableContainer,
 };
 
-const REDIS_IMAGE: &ImageName = &ImageName::new("redis");
+const REDIS_IMAGE: &ImageName = &ImageName::new("docker.io/redis");
 
 const PORT: Port = Port(6379);
 

--- a/rustainers/tests/common/images.rs
+++ b/rustainers/tests/common/images.rs
@@ -14,7 +14,7 @@ pub struct InternalWebServer;
 impl ToRunnableContainer for InternalWebServer {
     fn to_runnable(&self, builder: RunnableContainerBuilder) -> RunnableContainer {
         builder
-            .with_image(ImageName::new("nginx"))
+            .with_image(ImageName::new("docker.io/nginx"))
             .with_wait_strategy(
                 HealthCheck::builder()
                     .with_command("curl -sf http://localhost") //DevSkim: ignore DS137138
@@ -50,7 +50,7 @@ pub async fn curl(
 impl ToRunnableContainer for Curl {
     fn to_runnable(&self, builder: RunnableContainerBuilder) -> RunnableContainer {
         builder
-            .with_image(ImageName::new("curlimages/curl"))
+            .with_image(ImageName::new("docker.io/curlimages/curl"))
             .with_wait_strategy(WaitStrategy::State(ContainerStatus::Exited))
             .with_command(["-fsv", "--connect-timeout", "1", &self.url])
             .build()
@@ -70,7 +70,7 @@ impl Default for WebServer {
 impl ToRunnableContainer for WebServer {
     fn to_runnable(&self, builder: RunnableContainerBuilder) -> RunnableContainer {
         builder
-            .with_image(ImageName::new("nginx"))
+            .with_image(ImageName::new("docker.io/nginx"))
             .with_port_mappings([self.0.clone()])
             .with_wait_strategy(WaitStrategy::http("/"))
             .build()
@@ -123,7 +123,7 @@ impl Default for Netcat {
 impl ToRunnableContainer for Netcat {
     fn to_runnable(&self, builder: RunnableContainerBuilder) -> RunnableContainer {
         builder
-            .with_image(ImageName::new("alpine"))
+            .with_image(ImageName::new("docker.io/alpine"))
             .with_port_mappings([self.0.clone()])
             .with_wait_strategy(WaitStrategy::scan_port(Self::PORT))
             .with_command(["nc", "-vl", "8888"])


### PR DESCRIPTION
See: https://unix.stackexchange.com/a/701785

Still, new podman seems to have removed `compose` :(

> Error: Fail run compose in "/tmp/tc_redpanda-single_01J46P1QZGHZBS3E86NSCFAMQW" because Compose command is unsupported for Podman 5.1.2