### PR TITLE
chore: Update dependencies and MSRV to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: Continuous integration
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  MSRV: 1.67.0
+  MSRV: 1.70.0
 
 jobs:
   tests:

--- a/rustainers/Cargo.toml
+++ b/rustainers/Cargo.toml
@@ -13,7 +13,7 @@ description = "A simple, opinionated way to run containers for tests."
 readme = "README.md"
 repository = "https://github.com/wefoxplatform/rustainers"
 
-rust-version = "1.67.0" # toml_datetime
+rust-version = "1.70.0" # toml_datetime
 
 [features]
 default = []

--- a/rustainers/Cargo.toml
+++ b/rustainers/Cargo.toml
@@ -27,19 +27,19 @@ ensure-nerdctl = []
 very-long-tests = []
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.81"
 hex = { version = "0.4.3", features = ["serde"] }
-indexmap = "2.1.0"
+indexmap = "2.3.0"
 ipnetwork = "0.20.0"
 path-absolutize = "3.1.1"
-regex = { version = "1.10.3", optional = true }
-reqwest = { version = "0.11.24" }
-serde = { version = "1.0.190", features = ["derive", "rc"] }
-serde_json = "1.0.108"
-strum = "0.25.0"
-strum_macros = "0.25.0"
-thiserror = "1.0.40"
-tokio = { version = "1.34", features = [
+regex = { version = "1.10.6", optional = true }
+reqwest = { version = "0.12.5" }
+serde = { version = "1.0.204", features = ["derive", "rc"] }
+serde_json = "1.0.122"
+strum = "0.26.3"
+strum_macros = "0.26.4"
+thiserror = "1.0.63"
+tokio = { version = "1.39", features = [
   "time",
   "process",
   "fs",
@@ -47,22 +47,22 @@ tokio = { version = "1.34", features = [
   "io-util",
 ] }
 tracing = "0.1.40"
-typed-builder = "0.18.0"
-ulid = "1.1.0"
+typed-builder = "0.19.1"
+ulid = "1.1.3"
 
 [dev-dependencies]
 ahash = "=0.8.7"
 anyhow = "1.0"
 assert2 = "=0.3.11"
-bytes = "1.5"
-futures-util = "0.3.28"
-insta = { version = "1.29", features = ["json"] }
-mongodb = "2.7.1"
-object_store = { version = "0.8.0", features = ["aws"] }
+bytes = "1.7"
+futures-util = "0.3.30"
+insta = { version = "1.39", features = ["json"] }
+mongodb = "3.0.1"
+object_store = { version = "0.10.2", features = ["aws"] }
 rdkafka = { version = "0.36" }
-redis = "0.23"
-rstest = "0.18"
-tokio = { version = "1.34", features = ["macros", "rt-multi-thread"] }
+redis = "0.26"
+rstest = "0.22"
+tokio = { version = "1.39", features = ["macros", "rt-multi-thread"] }
 tokio-postgres = "0.7"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 

--- a/rustainers/examples/minio.rs
+++ b/rustainers/examples/minio.rs
@@ -2,7 +2,6 @@
 
 use std::time::Duration;
 
-use bytes::Bytes;
 use futures_util::StreamExt;
 use object_store::aws::AmazonS3Builder;
 use object_store::path::Path;
@@ -52,7 +51,7 @@ async fn do_something_in_minio(minio: &Container<Minio>, bucket_name: &str) -> a
         .build()?;
 
     // Store an object
-    s3.put(&Path::from("plop.txt"), Bytes::from_static(b"plop"))
+    s3.put(&Path::from("plop.txt"), b"plop"[..].into())
         .await?;
 
     // list objects

--- a/rustainers/examples/mongo.rs
+++ b/rustainers/examples/mongo.rs
@@ -47,9 +47,9 @@ async fn do_something_in_mongo(mongo: &Container<Mongo>) -> anyhow::Result<()> {
         doc! { "title": "The Great Gatsby", "author": "F. Scott Fitzgerald" },
     ];
 
-    collection.insert_many(docs, None).await?;
+    collection.insert_many(docs).await?;
 
-    let count = collection.count_documents(None, None).await?;
+    let count = collection.count_documents(Document::new()).await?;
 
     info!("Number of documents in the collection: {count}");
 


### PR DESCRIPTION
Update several dependencies (except for those that are explicitly pinned with `=`) and bump the MSRV to 1.70. That version of Rust was released [over a year ago](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html) so it should be a fairly conservative choice.

This PR unblocks https://github.com/wefoxplatform/rustainers/pull/26.