### PR TITLE
feat: support alternative TLS backends

### DIFF
--- a/rustainers/Cargo.toml
+++ b/rustainers/Cargo.toml
@@ -17,6 +17,9 @@ rust-version = "1.75.0"
 
 [features]
 default = []
+native-tls = ["reqwest/native-tls"]
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
 
 regex = ["dep:regex"]
 


### PR DESCRIPTION
Adds the `native-tls`, `rustls-tls-webpki-roots` and `rustls-tls-native-roots` feature flags. These are then forwarded to the `reqwest` feature flag counterparts.