### PR TITLE
fix: enable openssl removal from dependency tree

### DIFF
--- a/rustainers/Cargo.toml
+++ b/rustainers/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/wefoxplatform/rustainers"
 rust-version = "1.75.0"
 
 [features]
-default = []
+default = ["native-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
 rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
@@ -35,7 +35,11 @@ indexmap = "2.3.0"
 ipnetwork = { version = "0.21.1", features = ["serde"] }
 path-absolutize = "3.1.1"
 regex = { version = "1.10.6", optional = true }
-reqwest = { version = "0.12.5" }
+reqwest = { version = "0.12.5", default-features = false, features = [
+  "charset",
+  "http2",
+  "macos-system-configuration",
+] }
 serde = { version = "1.0.204", features = ["derive", "rc"] }
 serde_json = "1.0.122"
 strum = "0.26.3"


### PR DESCRIPTION
Sorry, missed one detail in #46 😅 

openssl-sys still being included when using a rustls backend feature flag.

Example usage:

```toml
# in Cargo.toml
rustainers = { version = "*", default-features = false, features = ["rustls-tls-webpki-roots"] }
```